### PR TITLE
feat: Use shell values for defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ dynamic: lib
 	$(AR) -x libmpfun90.a
 	$(CXX) -shared *.o -o libmpfun90.so
 
-	
+
 lib: libmpfun90.a
 
 
-FC = gfortran
-FFLAGS = -fno-automatic -O2 -funroll-all-loops -std=legacy -fPIC
+FC ?= gfortran
+FFLAGS ?= -fno-automatic -O2 -funroll-all-loops -std=legacy -fPIC
 
 
 MPFUN = mpfun90.o mpmod90.o mpmodm90.o mpmodx90.o


### PR DESCRIPTION
* Use the `?=` Make syntax to default to the environment variables for `FC` and `FFLAGS`, but provide defaults if they are not set.